### PR TITLE
Update deepin-metacity-3.22.23.ebuild

### DIFF
--- a/x11-wm/deepin-metacity/deepin-metacity-3.22.23.ebuild
+++ b/x11-wm/deepin-metacity/deepin-metacity-3.22.23.ebuild
@@ -49,7 +49,6 @@ DEPEND="${RDEPEND}
 	>=dev-util/intltool-0.35
 	virtual/pkgconfig
 	test? ( app-text/docbook-xml-dtd:4.5 )
-	xinerama? ( x11-proto/xineramaproto )
 	x11-base/xorg-proto"
 
 src_prepare() {


### PR DESCRIPTION
"x11-proto/xineramaproto" no longer exists and is included in "x11-base/xorg-proto".