### PR TITLE
Update deepin-screen-recorder-2.7.7.ebuild

### DIFF
--- a/media-gfx/deepin-screen-recorder/deepin-screen-recorder-2.7.7.ebuild
+++ b/media-gfx/deepin-screen-recorder/deepin-screen-recorder-2.7.7.ebuild
@@ -21,6 +21,8 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE="+gif +mp4"
 
+REQUIRED_USE="?? ( gif mp4 )"
+
 RDEPEND="dev-qt/qtwidgets:5
 		dev-qt/qtnetwork:5
 		dev-qt/qtgui:5


### PR DESCRIPTION
Based on https://github.com/zhtengw/deepin-overlay/issues/55#issuecomment-486178061 added `REQUIRED_USE="?? ( gif mp4 )"` as refferenced on https://devmanual.gentoo.org/ebuild-writing/variables/.

Fixes: https://github.com/zhtengw/deepin-overlay/issues/55

Signed-off-by: Jacob Hrbek <werifgx@gmail.com>