### PR TITLE
build fix for deepin-movie-reborn at profile 7.1

### DIFF
--- a/media-video/deepin-movie-reborn/deepin-movie-reborn-3.2.24.ebuild
+++ b/media-video/deepin-movie-reborn/deepin-movie-reborn-3.2.24.ebuild
@@ -44,12 +44,20 @@ RDEPEND="${DEPEND}
 		>=dde-base/dtkwidget-2.0.0:=
 		"
 
+src_prepare() {
+    LIBDIR=$(get_libdir)
+    sed -i "s|lib/|${LIBDIR}/|g" src/CMakeLists.txt || die
+    cmake-utils_src_prepare
+}
+
 pkg_postinst() {
     xdg_desktop_database_update
     xdg_mimeinfo_database_update
+    xdg_icon_cache_update
 }
 
 pkg_postrm() {
     xdg_desktop_database_update
     xdg_mimeinfo_database_update
+    xdg_icon_cache_update
 }


### PR DESCRIPTION
deepin-movie-reborn compile fails, when gentoo profile 7.1 is active.
This fixes the build.