### PR TITLE
build fix for Qt 5.13

### DIFF
--- a/dde-base/dde-qt5integration/dde-qt5integration-5.0.0-r1.ebuild
+++ b/dde-base/dde-qt5integration/dde-qt5integration-5.0.0-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+inherit qmake-utils
+
+DESCRIPTION="DDE system integration plugin for Qt5"
+HOMEPAGE="https://github.com/linuxdeepin/qt5integration"
+MY_PN=${PN#*-}
+MY_P=${MY_PN}-${PV}
+
+if [[ ${PV} = *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/linuxdeepin/${MY_PN}.git"
+else
+	SRC_URI="https://github.com/linuxdeepin/${MY_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+	S=${WORKDIR}/${MY_P}
+fi
+
+LICENSE="GPL-3"
+SLOT="0"
+IUSE=""
+
+RDEPEND="
+	dev-libs/libqtxdg
+	dev-qt/qtcore:5=
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	dev-qt/qtdbus:5
+	dev-qt/qtx11extras:5
+	dev-qt/qtmultimedia:5[widgets]
+	dev-qt/qtsvg:5
+	media-libs/fontconfig
+	media-libs/freetype
+	dev-qt/qt5dxcb-plugin
+	dev-qt/qtstyleplugins:5
+	"
+DEPEND="${RDEPEND}
+	dev-libs/glib:2
+	>=dde-base/dtkwidget-2.0.0:=
+	"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-qt5.13.patch
+)
+
+src_prepare() {
+	QT_SELECT=qt5 eqmake5 ${MY_PN}.pro
+	default
+}
+
+src_install() {
+	emake INSTALL_ROOT=${D} install
+}

--- a/dde-base/dde-qt5integration/files/dde-qt5integration-5.0.0-qt5.13.patch
+++ b/dde-base/dde-qt5integration/files/dde-qt5integration-5.0.0-qt5.13.patch
@@ -1,0 +1,12 @@
+--- a/dstyleplugin/style.cpp	2019-11-16 08:43:03.245556427 +0100
++++ b/dstyleplugin/style.cpp	2019-11-16 08:43:33.041960117 +0100
+@@ -1418,6 +1418,7 @@
+     }
+ }
+ 
+-#include "moc_style.cpp"
+ 
+ }
++
++#include "moc_style.cpp"
+

--- a/dev-qt/qtxcb-private-headers/Manifest
+++ b/dev-qt/qtxcb-private-headers/Manifest
@@ -1,2 +1,3 @@
 DIST qtbase-everywhere-src-5.12.3.tar.xz 48382148 SHA256 fddfd8852ef7503febeed67b876d1425160869ae2b1ae8e10b3fb0fedc5fe701
 DIST qtbase-everywhere-src-5.12.5.tar.xz 48463288 SHA256 fc8abffbbda9da3e593d8d62b56bc17dbaab13ff71b72915ddda11dabde4d625
+DIST qtbase-everywhere-src-5.13.2.tar.xz 48735704 SHA256 26b6b686d66a7ad28eaca349e55e2894e5a735f3831e45f2049e93b1daa92121

--- a/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.13.2.ebuild
+++ b/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.13.2.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="The Private Headers for the Qt5 Xcb"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 x86 ~amd64-fbsd"
+fi
+
+# TODO: linuxfb
+
+IUSE=""
+
+RDEPEND="
+	~dev-qt/qtgui-${PV}
+"
+DEPEND="${RDEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/plugins/platforms/xcb
+)
+
+
+#QT5_GENTOO_PRIVATE_CONFIG=(
+#	:gui
+#)
+
+
+src_compile() { :; }
+src_test() { :; }
+
+src_install() {
+	insinto ${QT5_HEADERDIR}/QtXcb/${PV}/QtXcb/private/
+	doins src/plugins/platforms/xcb/*.h
+}


### PR DESCRIPTION
This fixes building with and blocking of Qt 5.13.2 (current in ~amd64).

Patch reference: (https://github.com/linuxdeepin/qt5integration/commit/63861ee75c5b1492957c2bc93d797b4aa8b25c77)