### PR TITLE
Added qtxcb-private-headers 5.14.1

### DIFF
--- a/dev-qt/qtxcb-private-headers/Manifest
+++ b/dev-qt/qtxcb-private-headers/Manifest
@@ -2,3 +2,4 @@ DIST qtbase-everywhere-src-5.12.3.tar.xz 48382148 SHA256 fddfd8852ef7503febeed67
 DIST qtbase-everywhere-src-5.12.5.tar.xz 48463288 SHA256 fc8abffbbda9da3e593d8d62b56bc17dbaab13ff71b72915ddda11dabde4d625
 DIST qtbase-everywhere-src-5.13.2.tar.xz 48735704 SHA256 26b6b686d66a7ad28eaca349e55e2894e5a735f3831e45f2049e93b1daa92121
 DIST qtbase-everywhere-src-5.14.0.tar.xz 49713412 SHA256 4ef921c0f208a1624439801da8b3f4344a3793b660ce1095f2b7f5c4246b9463
+DIST qtbase-everywhere-src-5.14.1.tar.xz 49828188 SHA256 d9d423a6e7bcf1055c0372fc029f14a6fe67dd62c67b83095cde68b60b762cf7

--- a/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.14.1.ebuild
+++ b/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.14.1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="The Private Headers for the Qt5 Xcb"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 x86 ~amd64-fbsd"
+fi
+
+# TODO: linuxfb
+
+IUSE=""
+
+RDEPEND="
+	~dev-qt/qtgui-${PV}
+"
+DEPEND="${RDEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/plugins/platforms/xcb
+)
+
+
+#QT5_GENTOO_PRIVATE_CONFIG=(
+#	:gui
+#)
+
+
+src_compile() { :; }
+src_test() { :; }
+
+src_install() {
+	insinto ${QT5_HEADERDIR}/QtXcb/${PV}/QtXcb/private/
+	doins src/plugins/platforms/xcb/*.h
+}


### PR DESCRIPTION
dde-base/dde-meta would not merge (claimed dev-qt/qtgui was required through the multimedia flag) on a fresh install.

Fixes #69 