### PR TITLE
several fixes

### DIFF
--- a/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.12.3.ebuild
+++ b/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.12.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 QT5_MODULE="qtbase"
 inherit qt5-build
 

--- a/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.13.2.ebuild
+++ b/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.13.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 QT5_MODULE="qtbase"
 inherit qt5-build
 

--- a/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.14.1.ebuild
+++ b/dev-qt/qtxcb-private-headers/qtxcb-private-headers-5.14.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 QT5_MODULE="qtbase"
 inherit qt5-build
 

--- a/media-gfx/deepin-screen-recorder/deepin-screen-recorder-5.0.0-r1.ebuild
+++ b/media-gfx/deepin-screen-recorder/deepin-screen-recorder-5.0.0-r1.ebuild
@@ -30,7 +30,7 @@ RDEPEND="dev-qt/qtwidgets:5
 		dev-qt/qtx11extras:5
 		x11-libs/libXtst
 		gif? ( media-gfx/byzanz )
-		mp4? ( media-video/ffmpeg[xcb,x264] )
+		mp4? ( media-video/ffmpeg[x264] )
 		"
 
 DEPEND="${RDEPEND}

--- a/x11-wm/deepin-mutter/deepin-mutter-3.20.38-r2.ebuild
+++ b/x11-wm/deepin-mutter/deepin-mutter-3.20.38-r2.ebuild
@@ -79,6 +79,10 @@ RDEPEND="${COMMON_DEPEND}
 	!x11-misc/expocity
 "
 
+PATCHES=(
+        "${FILESDIR}/${PN}-giscan.patch"
+)
+
 src_configure() {
 	if use elogind; then
 		sed -i "s|libsystemd|libelogind|g" configure.ac

--- a/x11-wm/deepin-mutter/files/deepin-mutter-giscan.patch
+++ b/x11-wm/deepin-mutter/files/deepin-mutter-giscan.patch
@@ -1,0 +1,117 @@
+diff --git a/src/core/display.c b/src/core/display.c
+index 3232424..de85605 100644
+--- a/src/core/display.c
++++ b/src/core/display.c
+@@ -1183,7 +1183,7 @@ meta_get_display (void)
+ static inline gboolean
+ grab_op_is_window (MetaGrabOp op)
+ {
+-  return GRAB_OP_GET_BASE_TYPE (op) == META_GRAB_OP_WINDOW_BASE;
++  return META_GRAB_OP_GET_BASE_TYPE (op) == META_GRAB_OP_WINDOW_BASE;
+ }
+ 
+ gboolean
+@@ -1783,7 +1783,7 @@ get_first_freefloating_window (MetaWindow *window)
+ static MetaEventRoute
+ get_event_route_from_grab_op (MetaGrabOp op)
+ {
+-  switch (GRAB_OP_GET_BASE_TYPE (op))
++  switch (META_GRAB_OP_GET_BASE_TYPE (op))
+     {
+     case META_GRAB_OP_NONE:
+       /* begin_grab_op shouldn't be called with META_GRAB_OP_NONE. */
+diff --git a/src/core/screen.c b/src/core/screen.c
+index 17582ad..66cfd38 100644
+--- a/src/core/screen.c
++++ b/src/core/screen.c
+@@ -1740,7 +1740,7 @@ meta_screen_get_monitor_for_point (MetaScreen *screen,
+ 
+   for (i = 0; i < screen->n_monitor_infos; i++)
+     {
+-      if (POINT_IN_RECT (x, y, screen->monitor_infos[i].rect))
++      if (META_POINT_IN_RECT (x, y, screen->monitor_infos[i].rect))
+         return &screen->monitor_infos[i];
+     }
+ 
+diff --git a/src/core/stack.c b/src/core/stack.c
+index adccae0..5987c08 100644
+--- a/src/core/stack.c
++++ b/src/core/stack.c
+@@ -1222,7 +1222,7 @@ window_contains_point (MetaWindow *window,
+ 
+   meta_window_get_frame_rect (window, &rect);
+ 
+-  return POINT_IN_RECT (root_x, root_y, rect);
++  return META_POINT_IN_RECT (root_x, root_y, rect);
+ }
+ 
+ static MetaWindow*
+diff --git a/src/meta/common.h b/src/meta/common.h
+index 71ac256..7f2ca05 100644
+--- a/src/meta/common.h
++++ b/src/meta/common.h
+@@ -148,7 +148,7 @@ enum
+   _WGO_N = META_GRAB_OP_WINDOW_DIR_NORTH,
+ };
+ 
+-#define GRAB_OP_GET_BASE_TYPE(op) (op & 0x00FF)
++#define META_GRAB_OP_GET_BASE_TYPE(op) (op & 0x00FF)
+ 
+ typedef enum
+ {
+@@ -508,7 +508,7 @@ void meta_frame_borders_clear (MetaFrameBorders *self);
+ 
+ /************************************************************/
+ 
+-#define POINT_IN_RECT(xcoord, ycoord, rect) \
++#define META_POINT_IN_RECT(xcoord, ycoord, rect) \
+  ((xcoord) >= (rect).x &&                   \
+   (xcoord) <  ((rect).x + (rect).width) &&  \
+   (ycoord) >= (rect).y &&                   \
+diff --git a/src/ui/frames.c b/src/ui/frames.c
+index e6e523a..3202ddc 100644
+--- a/src/ui/frames.c
++++ b/src/ui/frames.c
+@@ -1621,19 +1621,19 @@ get_control (MetaUIFrame *frame, int root_x, int root_y)
+   meta_ui_frame_calc_geometry (frame, &fgeom);
+   get_client_rect (&fgeom, &client);
+ 
+-  if (POINT_IN_RECT (x, y, client))
++  if (META_POINT_IN_RECT (x, y, client))
+     return META_FRAME_CONTROL_CLIENT_AREA;
+ 
+-  if (POINT_IN_RECT (x, y, fgeom.close_rect.clickable))
++  if (META_POINT_IN_RECT (x, y, fgeom.close_rect.clickable))
+     return META_FRAME_CONTROL_DELETE;
+ 
+-  if (POINT_IN_RECT (x, y, fgeom.min_rect.clickable))
++  if (META_POINT_IN_RECT (x, y, fgeom.min_rect.clickable))
+     return META_FRAME_CONTROL_MINIMIZE;
+ 
+-  if (POINT_IN_RECT (x, y, fgeom.menu_rect.clickable))
++  if (META_POINT_IN_RECT (x, y, fgeom.menu_rect.clickable))
+     return META_FRAME_CONTROL_MENU;
+ 
+-  if (POINT_IN_RECT (x, y, fgeom.appmenu_rect.clickable))
++  if (META_POINT_IN_RECT (x, y, fgeom.appmenu_rect.clickable))
+     return META_FRAME_CONTROL_APPMENU;
+ 
+   flags = meta_frame_get_flags (frame->meta_window->frame);
+@@ -1645,7 +1645,7 @@ get_control (MetaUIFrame *frame, int root_x, int root_y)
+     (flags & META_FRAME_ALLOWS_TILED_RESIZE_LEFT) != 0 ||
+     (flags & META_FRAME_ALLOWS_TILED_RESIZE_RIGHT) != 0;
+ 
+-  if (POINT_IN_RECT (x, y, fgeom.title_rect))
++  if (META_POINT_IN_RECT (x, y, fgeom.title_rect))
+     {
+       if (has_vert && y <= TOP_RESIZE_HEIGHT && has_north_resize)
+         return META_FRAME_CONTROL_RESIZE_N;
+@@ -1653,7 +1653,7 @@ get_control (MetaUIFrame *frame, int root_x, int root_y)
+         return META_FRAME_CONTROL_TITLE;
+     }
+ 
+-  if (POINT_IN_RECT (x, y, fgeom.max_rect.clickable))
++  if (META_POINT_IN_RECT (x, y, fgeom.max_rect.clickable))
+     {
+       if (flags & META_FRAME_MAXIMIZED)
+         return META_FRAME_CONTROL_UNMAXIMIZE;


### PR DESCRIPTION
Gnome mutter changed macro names: [Gitlab GNOME/mutter, commit a8155a04](https://gitlab.gnome.org/GNOME/mutter/-/commit/a8155a04713704034d0f26ff1ac4b8446ddbb68f)
This let GIR generation fail. This patch fixes it.

media-video/ffmpeg dropped USE flag xcb: [Gentoo repo, media-video/ffmpeg, Commit 96cd4122b9f](https://gitweb.gentoo.org/repo/gentoo.git/commit/media-video/ffmpeg?id=96e577c5839c2fddcddfb0c1d876ba174e6dafd5)

qt5-build.eclass dropped EAPI 6 support: [Gentoo repo, eclasses, Commit 95eb6174320](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=89f20f13ea1260da3636d21c5c721bcc5bb21728)