### PR TITLE
go cache build fix

### DIFF
--- a/dde-base/dde-api/dde-api-5.1.11.1-r1.ebuild
+++ b/dde-base/dde-api/dde-api-5.1.11.1-r1.ebuild
@@ -74,6 +74,7 @@ src_compile() {
 	mkdir -p "${T}/golibdir/"
 	cp -r  "${S}/src/${EGO_PN}/vendor"  "${T}/golibdir/src"
 
+	export -n GOCACHE XDG_CACHE_HOME
 	export GOPATH="${S}:$(get_golibdir_gopath):${T}/golibdir/" 
 	cd ${S}/src/${EGO_PN}
 	emake


### PR DESCRIPTION
Fix for this build fail:
```
env GOPATH="/var/tmp/portage/dde-base/dde-api-5.1.11.1/work/dde-api-5.1.11.1/src/pkg.deepin.io/dde/api/gobuild:/var/tmp/portage/dde-base/dde-api-5.1.11.1/work/dde-api-5.1.11.1:/usr/lib/go-gentoo:/var/tmp/portage/dde-base/dde-api-5.1.11.1/temp/golibdir/" go build -o out/bin/device  pkg.deepin.io/dde/api/device
failed to initialize build cache at /root/.cache/go-build: mkdir /root/.cache/go-build: permission denied
make: *** [Makefile:58: out/bin/device] Error 1
 * ERROR: dde-base/dde-api-5.1.11.1::deepin failed (compile phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=dde-base/dde-api-5.1.11.1::deepin'`,
 * the complete build log and the output of `emerge -pqv '=dde-base/dde-api-5.1.11.1::deepin'`.
 * The complete build log is located at '/var/tmp/portage/dde-base/dde-api-5.1.11.1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dde-base/dde-api-5.1.11.1/temp/environment'.
 * Working directory: '/var/tmp/portage/dde-base/dde-api-5.1.11.1/work/dde-api-5.1.11.1/src/pkg.deepin.io/dde/api'
 * S: '/var/tmp/portage/dde-base/dde-api-5.1.11.1/work/dde-api-5.1.11.1'
```