### PR TITLE
deepin-screen-recorder build fix

### DIFF
--- a/media-gfx/deepin-screen-recorder/deepin-screen-recorder-5.8.0.11-r1.ebuild
+++ b/media-gfx/deepin-screen-recorder/deepin-screen-recorder-5.8.0.11-r1.ebuild
@@ -41,8 +41,12 @@ DEPEND="${RDEPEND}
 		dde-base/dtkgui:=
 		"
 
+PATCHES=(
+		"${FILESDIR}/${P}-build-fix.patch"
+)
+
 src_prepare() {
-	eapply_user
+	default
 	QT_SELECT=qt5 eqmake5 screen_shot_recorder.pro
 }
 

--- a/media-gfx/deepin-screen-recorder/files/deepin-screen-recorder-5.8.0.11-build-fix.patch
+++ b/media-gfx/deepin-screen-recorder/files/deepin-screen-recorder-5.8.0.11-build-fix.patch
@@ -1,0 +1,10 @@
+--- a/src/event_monitor.cpp
++++ b/src/event_monitor.cpp
+@@ -23,6 +23,7 @@
+ 
+ #include "event_monitor.h"
+ #include <X11/Xlibint.h>
++#undef min
+ #include <X11/Xutil.h>
+ #include <X11/cursorfont.h>
+ #include <X11/keysymdef.h>


### PR DESCRIPTION
Build fix for this error:
```
x86_64-pc-linux-gnu-g++ -c -march=native -O2 -pipe -fomit-frame-pointer -w -g -std=gnu++11 -Wall -Wextra -D_REENTRANT -fPIC -DDSR_LANG_PATH=\"/usr/share/deepin-screen-recorder/translations\" -DQT_NO_DEBUG -DQT_X11EXTRAS_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_MULTIMEDIA_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_DBUS_LIB -DQT_XML_LIB -DQT_NETWORK_LIB -DQT_CONCURRENT_LIB -DQT_CORE_LIB -I. -I. -isystem /usr/include/libdframeworkdbus-2.0 -isystem /usr/include/libdtk-5.2.0/DWidget -isystem /usr/include/libdtk-5.2.0/DGui -isystem /usr/include/qt5/QtWidgets/5.14.2 -isystem /usr/include/qt5/QtWidgets/5.14.2/QtWidgets -isystem /usr/include/qt5/QtGui/5.14.2 -isystem /usr/include/qt5/QtGui/5.14.2/QtGui -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtX11Extras -isystem /usr/include/qt5/QtMultimediaWidgets -isystem /usr/include/qt5/QtMultimedia -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/qt5/QtGui -isystem /usr/include/libdtk-5.2.0/DCore -isystem /usr/include/qt5/QtDBus -isystem /usr/include/qt5/QtXml -isystem /usr/include/qt5/QtCore/5.14.2 -isystem /usr/include/qt5/QtCore/5.14.2/QtCore -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtConcurrent -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-g++ -o event_monitor.o src/event_monitor.cpp
In file included from src/event_monitor.cpp:25:
/usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/include/g++-v10/bits/istream.tcc: In member function ‘std::streamsize std::basic_istream<_CharT, _Traits>::readsome(std::basic_istream<_CharT, _Traits>::char_type*, std::streamsize)’:
/usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/include/g++-v10/bits/istream.tcc:699:46: error: expected unqualified-id before ‘(’ token
  699 |   _M_gcount = this->rdbuf()->sgetn(__s, std::min(__num, __n));
      |                                              ^~~
make: *** [Makefile:1944: event_monitor.o] Error 1
 * ERROR: media-gfx/deepin-screen-recorder-5.8.0.11::deepin failed (compile phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=media-gfx/deepin-screen-recorder-5.8.0.11::deepin'`,
 * the complete build log and the output of `emerge -pqv '=media-gfx/deepin-screen-recorder-5.8.0.11::deepin'`.
 * The complete build log is located at '/var/tmp/portage/media-gfx/deepin-screen-recorder-5.8.0.11/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/media-gfx/deepin-screen-recorder-5.8.0.11/temp/environment'.
 * Working directory: '/var/tmp/portage/media-gfx/deepin-screen-recorder-5.8.0.11/work/deepin-screen-recorder-5.8.0.11'
 * S: '/var/tmp/portage/media-gfx/deepin-screen-recorder-5.8.0.11/work/deepin-screen-recorder-5.8.0.11'
```