### PR TITLE
deepin-log-viewer elogind fix

### DIFF
--- a/dde-extra/deepin-log-viewer/deepin-log-viewer-5.6.3-r1.ebuild
+++ b/dde-extra/deepin-log-viewer/deepin-log-viewer-5.6.3-r1.ebuild
@@ -10,10 +10,12 @@ DESCRIPTION="Deepin Log Viewer"
 HOMEPAGE="https://github.com/linuxdeepin/deepin-log-viewer"
 SRC_URI="https://github.com/linuxdeepin/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
+RESTRICT="mirror"
+
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="elogind systemd"
 
 RDEPEND="dev-qt/qtcore:5
 		dev-qt/qtwidgets:5
@@ -35,7 +37,12 @@ src_prepare() {
 	sed -i "/<QList>/a\#include\ <QIODevice>" \
 		thirdlib/docx/opc/packagereader.h || die
 
-	QT_SELECT=qt5 eqmake5 DEFINES+="VERSION=${PV}"
+	if use elogind && ! use systemd ; then
+		eapply "${FILESDIR}/${P}-elogind.patch"
+		QT_SELECT=qt5 eqmake5 DEFINES+="VERSION=${PV}" INCLUDEPATH+=/usr/include/elogind
+	else
+		QT_SELECT=qt5 eqmake5 DEFINES+="VERSION=${PV}"
+	fi
 	default_src_prepare
 }
 

--- a/dde-extra/deepin-log-viewer/files/deepin-log-viewer-5.6.3-elogind.patch
+++ b/dde-extra/deepin-log-viewer/files/deepin-log-viewer-5.6.3-elogind.patch
@@ -1,0 +1,16 @@
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -6,12 +6,10 @@ TARGET = deepin-log-viewer
+ TEMPLATE = app
+ CONFIG += c++11 link_pkgconfig
+ 
+-LIBS += -lsystemd
++LIBS += -lelogind
+ 
+ DEFINES += USE_POLKIT ENABLE_INACTIVE_DISPLAY
+ 
+-LIBS += -lsystemd
+-
+ include(../thirdlib/QtXlsxWriter/src/xlsx/qtxlsx.pri)
+ include(../thirdlib/docx/docx.pri)
+


### PR DESCRIPTION
Build fix for this error, when USE="elogind -systemd":
```
x86_64-pc-linux-gnu-g++ -c -march=native -O2 -pipe -fomit-frame-pointer -w -std=gnu++11 -Wall -Wextra -D_REENTRANT -fPIC -DVERSION=5.6.3 -DUSE_POLKIT -DENABLE_INACTIVE_DISPLAY -DXLSX_NO_LIB -DQT_NO_DEBUG -DQT_MULTIMEDIAWIDGETS_LIB -DQT_MULTIMEDIA_LIB -DQT_WIDGETS_LIB -DQT_X11EXTRAS_LIB -DQT_GUI_LIB -DQT_DBUS_LIB -DQT_XML_LIB -DQT_NETWORK_LIB -DQT_CONCURRENT_LIB -DQT_CORE_LIB -I. -I../thirdlib/QtXlsxWriter/src/xlsx -I../thirdlib/docx -isystem /usr/include/libdtk-5.2.0/DWidget -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtMultimediaWidgets -isystem /usr/include/qt5/QtMultimedia -isystem /usr/include/qt5/QtWidgets/5.14.2 -isystem /usr/include/qt5/QtWidgets/5.14.2/QtWidgets -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/libdtk-5.2.0/DGui -isystem /usr/include/qt5/QtGui/5.14.2 -isystem /usr/include/qt5/QtGui/5.14.2/QtGui -isystem /usr/include/qt5/QtX11Extras -isystem /usr/include/qt5/QtGui -isystem /usr/include/libdtk-5.2.0/DCore -isystem /usr/include/qt5/QtDBus -isystem /usr/include/qt5/QtXml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtConcurrent -isystem /usr/include/qt5/QtCore/5.14.2 -isystem /usr/include/qt5/QtCore/5.14.2/QtCore -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-g++ -o journalwork.o journalwork.cpp
journalwork.cpp:86:10: fatal error: systemd/sd-journal.h: No such file or directory
   86 | #include <systemd/sd-journal.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:1584: journalwork.o] Error 1
make[1]: Leaving directory '/var/tmp/portage/dde-extra/deepin-log-viewer-5.6.3/work/deepin-log-viewer-5.6.3/src'
make: *** [Makefile:48: sub-src-make_first] Error 2
 * ERROR: dde-extra/deepin-log-viewer-5.6.3::deepin failed (compile phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=dde-extra/deepin-log-viewer-5.6.3::deepin'`,
 * the complete build log and the output of `emerge -pqv '=dde-extra/deepin-log-viewer-5.6.3::deepin'`.
 * The complete build log is located at '/var/tmp/portage/dde-extra/deepin-log-viewer-5.6.3/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dde-extra/deepin-log-viewer-5.6.3/temp/environment'.
 * Working directory: '/var/tmp/portage/dde-extra/deepin-log-viewer-5.6.3/work/deepin-log-viewer-5.6.3'
 * S: '/var/tmp/portage/dde-extra/deepin-log-viewer-5.6.3/work/deepin-log-viewer-5.6.3'
```