### PR TITLE
dde-daemon go cache fix

### DIFF
--- a/dde-base/dde-daemon/dde-daemon-5.10.0.1-r1.ebuild
+++ b/dde-base/dde-daemon/dde-daemon-5.10.0.1-r1.ebuild
@@ -36,6 +36,8 @@ HOMEPAGE="https://github.com/linuxdeepin/dde-daemon"
 SRC_URI="https://github.com/linuxdeepin/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 ${EGO_VENDOR_URI}"
 
+RESTRICT="mirror"
+
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
@@ -117,6 +119,7 @@ src_prepare() {
 
 src_compile() {
 	cd ${S}/src/${EGO_PN}
+	export -n GOCACHE XDG_CACHE_HOME
 	export PAM_MODULE_DIR=$(getpam_mod_dir)
 	default_src_compile
 }


### PR DESCRIPTION
Build fix for this error:
```
env GOPATH="/var/tmp/portage/dde-base/dde-daemon-5.10.0.1/work/dde-daemon-5.10.0.1/src/pkg.deepin.io/dde/daemon/gopath:/var/tmp/portage/dde-base/dde-daemon-5.10.0.1/work/dde-daemon-5.10.0.1:/usr/lib/go-gentoo:/var/tmp/portage/dde-base/dde-daemon-5.10.0.1/temp/golibdir/" go build -o out/bin/default-terminal  pkg.deepin.io/dde/daemon/bin/default-terminal
failed to initialize build cache at /root/.cache/go-build: mkdir /root/.cache/go-build: permission denied
make: *** [Makefile:32: out/bin/default-terminal] Error 1
 * ERROR: dde-base/dde-daemon-5.10.0.1::deepin failed (compile phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=dde-base/dde-daemon-5.10.0.1::deepin'`,
 * the complete build log and the output of `emerge -pqv '=dde-base/dde-daemon-5.10.0.1::deepin'`.
 * The complete build log is located at '/var/tmp/portage/dde-base/dde-daemon-5.10.0.1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dde-base/dde-daemon-5.10.0.1/temp/environment'.
 * Working directory: '/var/tmp/portage/dde-base/dde-daemon-5.10.0.1/work/dde-daemon-5.10.0.1/src/pkg.deepin.io/dde/daemon'
 * S: '/var/tmp/portage/dde-base/dde-daemon-5.10.0.1/work/dde-daemon-5.10.0.1'
```