### PR TITLE
startdde go cache fix

### DIFF
--- a/dde-base/startdde/startdde-5.3.0.1-r1.ebuild
+++ b/dde-base/startdde/startdde-5.3.0.1-r1.ebuild
@@ -19,6 +19,8 @@ HOMEPAGE="https://github.com/linuxdeepin/startdde"
 SRC_URI="https://github.com/linuxdeepin/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 		${EGO_VENDOR_URI}"
 
+RESTRICT="mirror"
+
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
@@ -44,6 +46,7 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	mkdir -p "${T}/golibdir/"
 	cp -r  "${S}/src/${EGO_PN}/vendor"  "${T}/golibdir/src"
+	export -n GOCACHE XDG_CACHE_HOME
 	export GOPATH="${S}:$(get_golibdir_gopath):${T}/golibdir/"
 
 	LIBDIR=$(get_libdir)


### PR DESCRIPTION
Build fix for this error:
```
env GOPATH="/var/tmp/portage/dde-base/startdde-5.3.0.1/work/startdde-5.3.0.1/src/startdde/gopath:/var/tmp/portage/dde-base/startdde-5.3.0.1/work/startdde-5.3.0.1:/usr/lib/go-gentoo:/var/tmp/portage/dde-base/startdde-5.3.0.1/temp/golibdir/" go build -v -o startdde
failed to initialize build cache at /root/.cache/go-build: mkdir /root/.cache/go-build: permission denied
make: *** [Makefile:24: startdde] Error 1
 * ERROR: dde-base/startdde-5.3.0.1::deepin failed (compile phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=dde-base/startdde-5.3.0.1::deepin'`,
 * the complete build log and the output of `emerge -pqv '=dde-base/startdde-5.3.0.1::deepin'`.
 * The complete build log is located at '/var/tmp/portage/dde-base/startdde-5.3.0.1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dde-base/startdde-5.3.0.1/temp/environment'.
 * Working directory: '/var/tmp/portage/dde-base/startdde-5.3.0.1/work/startdde-5.3.0.1/src/startdde'
 * S: '/var/tmp/portage/dde-base/startdde-5.3.0.1/work/startdde-5.3.0.1'
```