### PR TITLE
go-dbus-factory go cache fix

### DIFF
--- a/dev-go/go-dbus-factory/go-dbus-factory-1.6.4.ebuild
+++ b/dev-go/go-dbus-factory/go-dbus-factory-1.6.4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=6
+EAPI=7
 
 EGO_PN="github.com/linuxdeepin/go-dbus-factory"
 
@@ -14,6 +14,8 @@ DESCRIPTION="Go bindings to generate D-Bus services"
 HOMEPAGE="https://github.com/linuxdeepin/go-dbus-factory"
 SRC_URI="https://github.com/linuxdeepin/go-dbus-factory/archive/${PV}.tar.gz -> ${P}.tar.gz
 ${EGO_VENDOR_URI}"
+
+RESTRICT="mirror"
 
 LICENSE="GPL-3+"
 SLOT="0"
@@ -28,6 +30,7 @@ src_compile() {
 	mkdir -p "${T}/golibdir/"
 	cp -r  "${S}/src/${EGO_PN}/vendor"  "${T}/golibdir/src"
 
+	export -n GOCACHE XDG_CACHE_HOME
 	export GOPATH="${S}:$(get_golibdir_gopath):${T}/golibdir/"
 	cd ${S}/src/${EGO_PN}
 	emake bin


### PR DESCRIPTION
Fix for dreaded go cache failure during build:
```
go build -o generator _tool/generator/*.go
failed to initialize build cache at /root/.cache/go-build: mkdir /root/.cache/go-build: permission denied
make: *** [Makefile:12: bin] Error 1
 * ERROR: dev-go/go-dbus-factory-1.6.4::deepin failed (compile phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=dev-go/go-dbus-factory-1.6.4::deepin'`,
 * the complete build log and the output of `emerge -pqv '=dev-go/go-dbus-factory-1.6.4::deepin'`.
 * The complete build log is located at '/var/tmp/portage/dev-go/go-dbus-factory-1.6.4/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-go/go-dbus-factory-1.6.4/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-go/go-dbus-factory-1.6.4/work/go-dbus-factory-1.6.4/src/github.com/linuxdeepin/go-dbus-factory'
 * S: '/var/tmp/portage/dev-go/go-dbus-factory-1.6.4/work/go-dbus-factory-1.6.4'
```