### PR TITLE
go-gir-generator go cache fix

### DIFF
--- a/dev-go/go-gir-generator/go-gir-generator-2.0.2-r1.ebuild
+++ b/dev-go/go-gir-generator/go-gir-generator-2.0.2-r1.ebuild
@@ -12,6 +12,8 @@ DESCRIPTION="Generate static golang bindings for GObject"
 HOMEPAGE="https://github.com/linuxdeepin/go-gir-generator"
 SRC_URI="https://github.com/linuxdeepin/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
+RESTRICT="mirror"
+
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
@@ -24,6 +26,7 @@ DEPEND="dev-libs/gobject-introspection
 src_prepare() {
 	# fix with >=dev-libs/glib-2.63
 	sed -i "s/\"connect\"/\"connect\"\,\n\"source_new\"/" lib.in/gio-2.0/config.json || die
+	export -n GOCACHE XDG_CACHE_HOME
 	default_src_prepare
 }
 


### PR DESCRIPTION
Fix for go-gir-generator go cache build fail:
```
cp -r  lib.in/gudev-1.0     out/src/pkg.deepin.io/gir/
failed to initialize build cache at /root/.cache/go-build: mkdir /root/.cache/go-build: permission denied
make: *** [Makefile:18: generator] Error 1
 * ERROR: dev-go/go-gir-generator-2.0.2-r1::deepin failed (compile phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=dev-go/go-gir-generator-2.0.2-r1::deepin'`,
 * the complete build log and the output of `emerge -pqv '=dev-go/go-gir-generator-2.0.2-r1::deepin'`.
 * The complete build log is located at '/var/tmp/portage/dev-go/go-gir-generator-2.0.2-r1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-go/go-gir-generator-2.0.2-r1/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-go/go-gir-generator-2.0.2-r1/work/go-gir-generator-2.0.2'
 * S: '/var/tmp/portage/dev-go/go-gir-generator-2.0.2-r1/work/go-gir-generator-2.0.2'
```