### PR TITLE
x11-libs/gsettings-qt: remove deleted bzr eclass

### DIFF
--- a/x11-libs/gsettings-qt/gsettings-qt-0.1_p20170824.ebuild
+++ b/x11-libs/gsettings-qt/gsettings-qt-0.1_p20170824.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 EBZR_REPO_URI="lp:gsettings-qt"
 
-inherit qmake-utils bzr
+inherit qmake-utils
 
 DESCRIPTION="Qml bindings for GSettings."
 HOMEPAGE="https://launchpad.net/gsettings-qt"


### PR DESCRIPTION
Eclass `bzr` was removed from portage tree: https://github.com/gentoo/gentoo/commit/79a3d7f7c3ca5f1af64f0d5e60cd490ca62f3c05

This leads to this error:
```
* ERROR: x11-libs/gsettings-qt-0.1_p20170824::deepin failed (depend phase):
 *   bzr.eclass could not be found by inherit()
 * 
 * Call stack:
 \ *                           ebuild.sh, line 609:  Called source '/var/lib/layman/deepin/x11-libs/gsettings-qt/gsettings-qt-0.1_p20170824.ebuild'
 *   gsettings-qt-0.1_p20170824.ebuild, line   8:  Called inherit 'qmake-utils' 'bzr'
 *                           ebuild.sh, line 290:  Called die
 * The specific snippet of code:
 *   		[[ -z ${location} ]] && die "${1}.eclass could not be found by inherit()"
 * 
 * If you need support, post the output of `emerge --info '=x11-libs/gsettings-qt-0.1_p20170824::deepin'`,
 * the complete build log and the output of `emerge -pqv '=x11-libs/gsettings-qt-0.1_p20170824::deepin'`.
 * Working directory: '/usr/lib/python3.7/site-packages'
 * S: '/var/tmp/portage/x11-libs/gsettings-qt-0.1_p20170824/work/gsettings-qt-0.1_p20170824'
```

Removing bzr eclass, fixing the error. Can't tell, if this breaks the ebuild or if this ebuild is still needed at all. 