### PR TITLE
add deepin-terminal-old

### DIFF
--- a/dde-base/dde-meta/dde-meta-20.ebuild
+++ b/dde-base/dde-meta/dde-meta-20.ebuild
@@ -38,5 +38,5 @@ RDEPEND=">=dde-base/dde-control-center-5.0.33
 		"
 
 pkg_postinst() {
-	use terminal && dfmterm deepin-terminal
+	( use terminal || use terminal-old ) && dfmterm deepin-terminal
 }

--- a/dde-base/dde-meta/dde-meta-20.ebuild
+++ b/dde-base/dde-meta/dde-meta-20.ebuild
@@ -11,9 +11,10 @@ SRC_URI=""
 LICENSE="metapackage"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="policykit manual +terminal multimedia grub plymouth elogind systemd turbo +kwin mutter extra screensaver"
+IUSE="policykit manual +terminal terminal-old multimedia grub plymouth elogind systemd turbo +kwin mutter extra screensaver"
 REQUIRED_USE="^^ ( systemd elogind )
-			?? ( kwin mutter )"
+			?? ( kwin mutter )
+			?? ( terminal terminal-old )"
 
 RDEPEND=">=dde-base/dde-control-center-5.0.33
 		virtual/dde-wm[kwin?,mutter?]
@@ -30,6 +31,7 @@ RDEPEND=">=dde-base/dde-control-center-5.0.33
 		turbo? ( dde-extra/deepin-turbo[systemd?,elogind?] )
 		manual? ( >=dde-extra/deepin-manual-5.6.0 )
 		terminal? ( dde-extra/deepin-terminal )
+		terminal-old? ( dde-extra/deepin-terminal-old )
 		multimedia? ( dde-extra/dde-meta-multimedia )
 		extra? ( ~dde-extra/dde-meta-apps-${PV} )
 		plymouth? ( dde-extra/plymouth-theme-deepin )

--- a/dde-base/dde-meta/metadata.xml
+++ b/dde-base/dde-meta/metadata.xml
@@ -8,6 +8,7 @@
 	<use>
 		<flag name="manual">Install <pkg>dde-extra/dde-help</pkg> User Manual</flag>
 		<flag name="terminal">Install <pkg>dde-extra/deepin-terminal</pkg> Terminal Emulator</flag>
+		<flag name="terminal-old">Install <pkg>dde-extra/deepin-terminal-old</pkg> Terminal Emulator (old version)</flag>
 		<flag name="extra">Install extra applicaions developed by Deepin</flag>
 		<flag name="multimedia">Install Deepin multimedia suite</flag>
 		<flag name="grub">Install Deepin themes for <pkg>sys-boot/grub</pkg></flag>

--- a/dde-extra/deepin-terminal-old/Manifest
+++ b/dde-extra/deepin-terminal-old/Manifest
@@ -1,0 +1,1 @@
+DIST deepin-terminal-old-5.0.4.1.tar.gz 2102734 SHA256 5274c53db29c54ef7c382c7e6924c597ea063d875c0d3fb8d7f4f245e44cf58f

--- a/dde-extra/deepin-terminal-old/deepin-terminal-old-5.0.4.1.ebuild
+++ b/dde-extra/deepin-terminal-old/deepin-terminal-old-5.0.4.1.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	dev-libs/json-glib
 	>=x11-libs/vte-0.50.1:2.91[vala]
 	zssh? ( net-misc/zssh )
-	!!dde-extra/deepin-terminal
+	!dde-extra/deepin-terminal
 	"
 DEPEND="${RDEPEND}
 	$(vala_depend)

--- a/dde-extra/deepin-terminal-old/deepin-terminal-old-5.0.4.1.ebuild
+++ b/dde-extra/deepin-terminal-old/deepin-terminal-old-5.0.4.1.ebuild
@@ -1,0 +1,58 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=7
+
+VALA_MIN_API_VERSION=0.22
+
+inherit vala cmake-utils
+
+DESCRIPTION="Deepin Terminal"
+HOMEPAGE="https://github.com/linuxdeepin/deepin-terminal-old"
+SRC_URI="https://github.com/linuxdeepin/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+RESTRICT="mirror"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+zssh"
+
+RDEPEND="
+	>=dev-libs/glib-2.32:2
+	dev-libs/libgee:0.8
+	>=x11-libs/gtk+-3.4:3
+	app-crypt/libsecret[vala]
+	x11-libs/libwnck:3
+	dde-base/deepin-menu
+	dev-tcltk/expect
+	dev-libs/json-glib
+	>=x11-libs/vte-0.50.1:2.91[vala]
+	zssh? ( net-misc/zssh )
+	!!dde-extra/deepin-terminal
+	"
+DEPEND="${RDEPEND}
+	$(vala_depend)
+	gnome-base/librsvg:2[vala]
+	dev-util/gperf
+	dev-libs/gobject-introspection
+	"
+
+src_prepare() {
+	vala_src_prepare
+	sed -i -e "/NAMES/s:valac:${VALAC}:" cmake/FindVala.cmake || die 
+	sed -i "s|lib/\${target}|$(get_libdir)/\${target}|g" CMakeLists.txt
+
+	cmake-utils_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		VALAC="${VALAC}"
+		-DTEST_BUILD=0
+		-DUSE_VENDOR_LIB=0
+		-DVERSION=${PV}
+	)
+	cmake-utils_src_configure
+}

--- a/dde-extra/deepin-terminal-old/metadata.xml
+++ b/dde-extra/deepin-terminal-old/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<email>atenzd@gmail.com</email>
+		<name>Aten Zhang</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">linuxdeepin/deepin-terminal-old</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/dde-extra/deepin-terminal/deepin-terminal-5.2.6.ebuild
+++ b/dde-extra/deepin-terminal/deepin-terminal-5.2.6.ebuild
@@ -28,6 +28,7 @@ RDEPEND="dev-qt/qtcore:5
 	dev-qt/qtconcurrent:5
 	>=dde-base/dtkcore-5.1.2
 	dde-base/dtkgui
+	!!dde-extra/deepin-terminal-old
 	"
 DEPEND="${RDEPEND}
 	dev-util/lxqt-build-tools
@@ -50,4 +51,3 @@ src_configure() {
 	)
 	cmake-utils_src_configure
 }
-

--- a/dde-extra/deepin-terminal/deepin-terminal-5.2.6.ebuild
+++ b/dde-extra/deepin-terminal/deepin-terminal-5.2.6.ebuild
@@ -28,7 +28,7 @@ RDEPEND="dev-qt/qtcore:5
 	dev-qt/qtconcurrent:5
 	>=dde-base/dtkcore-5.1.2
 	dde-base/dtkgui
-	!!dde-extra/deepin-terminal-old
+	!dde-extra/deepin-terminal-old
 	"
 DEPEND="${RDEPEND}
 	dev-util/lxqt-build-tools


### PR DESCRIPTION
The new [github/deepin-terminal](https://github.com/linuxdeepin/deepin-terminal) is missing the nice themes it had before. The old version is still available at [github/deepin-terminal-old](https://github.com/linuxdeepin/deepin-terminal-old).

Because I like the old version more, there is this PR.

It's adding a new USE flag **terminal-old** to dde-base/dde-meta.
It's made sure, that only one of the USE flags is set and only one of the packages are installed.